### PR TITLE
Added copyright headers

### DIFF
--- a/src/Core/AbstractConfig.js
+++ b/src/Core/AbstractConfig.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 class AbstractConfig {
 
 

--- a/src/Core/AbstractConnector.js
+++ b/src/Core/AbstractConnector.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 class AbstractConnector {
 
   /**

--- a/src/Core/AbstractPipeline.js
+++ b/src/Core/AbstractPipeline.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 class AbstractPipeline {
 
 constructor(config, connector, storage = null) {

--- a/src/Core/AbstractStorage.js
+++ b/src/Core/AbstractStorage.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 class AbstractStorage {
 
 constructor(config, uniqueKeyColumns) {

--- a/src/Core/GoogleSheetsConfig.js
+++ b/src/Core/GoogleSheetsConfig.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var GoogleSheetsConfig = class GoogleSheetsConfig extends AbstractConfig {
 
 constructor(configRange) {

--- a/src/Core/GoogleSheetsStorage.js
+++ b/src/Core/GoogleSheetsStorage.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var GoogleSheetsStorage = class GoogleSheetsStorage extends AbstractStorage {
 
   /**

--- a/src/Integrations/BankOfCanada/Code.gs
+++ b/src/Integrations/BankOfCanada/Code.gs
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 // Google Sheets Range with config data. Must me referes to a table with three columns: name, value and comment
 var CONFIG_RANGE = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Config').getRange("A:C");
 

--- a/src/Integrations/BankOfCanada/Connector.js
+++ b/src/Integrations/BankOfCanada/Connector.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var BankOfCanadaConnector = class BankOfCanadaConnector extends AbstractConnector {
 
   constructor( configRange ) {

--- a/src/Integrations/BankOfCanada/Pipeline.js
+++ b/src/Integrations/BankOfCanada/Pipeline.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var BankOfCanadaPipeline = class BankOfCanadaPipeline extends AbstractPipeline {
 
 

--- a/src/Integrations/FacebookMarketing/Connector.js
+++ b/src/Integrations/FacebookMarketing/Connector.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var FacebookMarketingConnector = class FacebookMarketingConnector extends AbstractConnector {
 
   constructor( config ) {

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var FacebookMarketingFieldsSchema = {
     "ad-account-user": {
         "overview": "Ad Account User",

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-ads.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-ads.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adAccountAdsFields = {
 'id': {
     'description': 'The ID of this ad',

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-creatives.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-creatives.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adAccountCreativesFields = {
 'id': {
   'description': 'Unique ID for an ad creative, numeric string',

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adAccountFields = {
 
 'id': {

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-insights-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-insights-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adAccountInsightsFields = {
 
 'account_currency': {

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-user-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-account-user-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adAccountUserFields = {
 
 'id': {

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-campaign-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-campaign-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adCampaignFields = {
 'id': {
   'description': 'ID for the Ad Set',

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-campaign-group-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-campaign-group-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adCampaignGroupFields = {
 'id': {
   'description': 'The ID of this ad.',

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-campaign-group-insights-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-campaign-group-insights-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adCampaignGroupInsightsFields = {
 'account_currency': {
   'description': 'Currency that is used by your ad account.',

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-campaign-insignts-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-campaign-insignts-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adCampaignInsightsFields = {
 
 'account_currency': {

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-creative-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-creative-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adCreativeFields = {
 'id': {
   'description': 'Unique ID for an ad creative, numeric string.',

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-group-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-group-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adGroupFields = {
 'id': {
   'description': 'The ID of this ad.',

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-group-insights-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-group-insights-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adGroupInsightsFields = {
 'account_currency': {
   'description': 'Currency that is used by your ad account.',

--- a/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-insights-breakdown-fields.js
+++ b/src/Integrations/FacebookMarketing/MarketingAPIReference/ad-insights-breakdown-fields.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var adInsightsBreakDownFields = {
 'action_device': {
   'description': 'The device on which the conversion event you\'re tracking occurred. For example, \""Desktop\"" if someone converted on a desktop computer.',

--- a/src/Integrations/FacebookMarketing/Pipeline.js
+++ b/src/Integrations/FacebookMarketing/Pipeline.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var FacebookMarketingPipeline = class FacebookMarketingPipeline extends AbstractPipeline {
 
 

--- a/src/Integrations/OpenExchangeRates/Code.gs
+++ b/src/Integrations/OpenExchangeRates/Code.gs
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 // Google Sheets Range with config data. Must me referes to a table with three columns: name, value and comment
 var CONFIG_RANGE = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Config').getRange("A:C");
 

--- a/src/Integrations/OpenExchangeRates/Connector.js
+++ b/src/Integrations/OpenExchangeRates/Connector.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 // API Documentation: https://docs.openexchangerates.org/reference/historical-json
 
 var OpenExchangeRatesConnector = class OpenExchangeRatesConnector extends AbstractConnector {

--- a/src/Integrations/OpenExchangeRates/Pipeline.js
+++ b/src/Integrations/OpenExchangeRates/Pipeline.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var OpenExchangeRatesPipeline = class OpenExchangeRatesPipeline extends AbstractPipeline {
 
 

--- a/src/Integrations/OpenHolidays/Code.gs
+++ b/src/Integrations/OpenHolidays/Code.gs
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 // Google Sheets Range with config data. Must me referes to a table with three columns: name, value and comment
 var CONFIG_RANGE = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Config').getRange("A:C");
 

--- a/src/Integrations/OpenHolidays/Connector.js
+++ b/src/Integrations/OpenHolidays/Connector.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 // API Documentation: https://www.openholidaysapi.org/en/#__tabbed_6_1
 
 var OpenHolidaysConnector = class OpenHolidaysConnector extends AbstractConnector {

--- a/src/Integrations/OpenHolidays/Pipeline.js
+++ b/src/Integrations/OpenHolidays/Pipeline.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var OpenHolidaysPipeline = class OpenHolidaysPipeline extends AbstractPipeline {
     startImportProcess() {
         this.config.logMessage("🔄 Starting import process for public holidays");

--- a/src/Templates/PublicEndPoint/Connector.js
+++ b/src/Templates/PublicEndPoint/Connector.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var YOUR_DATE_SOURCE_Connector = class YOUR_DATE_SOURCE_Connector extends AbstractConnector {
 
   constructor( configRange ) {

--- a/src/Templates/PublicEndPoint/Pipeline.js
+++ b/src/Templates/PublicEndPoint/Pipeline.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 var YOUR_DATE_SOURCE_Pipeline = class YOUR_DATE_SOURCE_Pipeline extends AbstractPipeline {
 
 


### PR DESCRIPTION
I've used `eslint` and `eslint-plugin-headers` in this pull request. While I’m not enforcing this tooling at the moment, I’ve shared the configuration below as a reference for future discussions and potential usage.

`package.json`:
```json
{
  "type": "module",
  "name": "js-data-connectors",
  "version": "1.0.0",
  "devDependencies": {
    "eslint": "^9.19.0",
    "eslint-plugin-headers": "^1.2.1"
  }
}
```

`eslint.config.js`:
```js
/**
 * Copyright (c) OWOX, Inc.
 *
 * For the full copyright and license information, please view the LICENSE
 * file that was distributed with this source code.
 */

import headers from "eslint-plugin-headers";

export default [
    {
        files: ["**/*.js", "**/*.gs"], // Apply to .js and .gs files
        plugins: {
            headers,
        },
        rules: {
            "headers/header-format": [
                "error",
                {
                    source: "string", // Use a string to define the header content
                    content: `Copyright (c) OWOX, Inc.
                    
For the full copyright and license information, please view the LICENSE
file that was distributed with this source code.`,
                    style: "jsdoc", // Use JSDoc-style block comments
                    trailingNewlines: 2, // Enforce 2 empty line after the header
                },
            ],
        },
    },
];
```

Usage:
```
npx eslint . --fix
```